### PR TITLE
Add an option to set the initial value passed to the reducer

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -173,21 +173,25 @@ The initial value passed to the [reducer][reduce]. The default is an empty objec
 
 ```js
 // file: /home/jdoe/my-module/index.js
+const defaultDependencies = {
+    clover: require('clover'),
+    unicorn: require('unicorn'),
+};
+
 requireGlob('./src/**/*.js', {
-    initialValue: [],
-    reducer: (options, result, fileObject) => {
-        result.push(fileObject.path);
-        return result;
-    }
+    initialValue: defaultDependencies,
 });
 
 // reducer example is changed to
-[
-    '/home/jdoe/my-module/src/unicorn.js',
-    '/home/jdoe/my-module/src/rainbow/red-orange.js',
-    '/home/jdoe/my-module/src/rainbow/_yellow_green.js',
-    '/home/jdoe/my-module/src/rainbow/BluePurple.js',
-]
+{
+    clover: require('clover'),
+    unicorn: require('./src/unicorn.js'),
+    rainbow: {
+        redOrange: require('./src/rainbow/red-orange.js'),
+        _yellow_green: require('./src/rainbow/_yellow_green.js'),
+        BluePurple: require('./src/rainbow/BluePurple.js'),
+    }
+}
 ```
 
 ##### keygen

--- a/readme.md
+++ b/readme.md
@@ -163,7 +163,7 @@ The [reducer][reduce] is responsible for generating the final object structure. 
 }
 ```
 
-##### default
+##### initialValue
 
 Type: `{any}` (default: `{}`)
 
@@ -174,7 +174,7 @@ The initial value passed to the [reducer][reduce]. The default is an empty objec
 ```js
 // file: /home/jdoe/my-module/index.js
 requireGlob('./src/**/*.js', {
-    default: [],
+    initialValue: [],
     reducer: (options, result, fileObject) => {
         result.push(fileObject.path);
         return result;

--- a/readme.md
+++ b/readme.md
@@ -163,6 +163,33 @@ The [reducer][reduce] is responsible for generating the final object structure. 
 }
 ```
 
+##### default
+
+Type: `{any}` (default: `{}`)
+
+The initial value passed to the [reducer][reduce]. The default is an empty object, as expected by the default reducer.
+
+[reduce]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce
+
+```js
+// file: /home/jdoe/my-module/index.js
+requireGlob('./src/**/*.js', {
+    default: [],
+    reducer: (options, result, fileObject) => {
+        result.push(fileObject.path);
+        return result;
+    }
+});
+
+// reducer example is changed to
+[
+    '/home/jdoe/my-module/src/unicorn.js',
+    '/home/jdoe/my-module/src/rainbow/red-orange.js',
+    '/home/jdoe/my-module/src/rainbow/_yellow_green.js',
+    '/home/jdoe/my-module/src/rainbow/BluePurple.js',
+]
+```
+
 ##### keygen
 
 Type: `{Function(options, fileObj): String|Array.<String>}`

--- a/src/require-glob.js
+++ b/src/require-glob.js
@@ -83,7 +83,7 @@ function keygen(options, fileObj) {
 }
 
 function mapReduce(options, filePaths) {
-	return filePaths.map(options.mapper).reduce(options.reducer, {});
+	return filePaths.map(options.mapper).reduce(options.reducer, options.default);
 }
 
 // API
@@ -98,6 +98,8 @@ function normalizeOptions(pattern, options) {
 	options.mapper = (options.mapper || mapper).bind(null, options);
 	options.reducer = (options.reducer || reducer).bind(null, options);
 	options.keygen = (options.keygen || keygen).bind(null, options);
+
+	options.default = (options.default || {});
 
 	return options;
 }

--- a/src/require-glob.js
+++ b/src/require-glob.js
@@ -83,7 +83,7 @@ function keygen(options, fileObj) {
 }
 
 function mapReduce(options, filePaths) {
-	return filePaths.map(options.mapper).reduce(options.reducer, options.default);
+	return filePaths.map(options.mapper).reduce(options.reducer, options.initialValue);
 }
 
 // API
@@ -99,7 +99,7 @@ function normalizeOptions(pattern, options) {
 	options.reducer = (options.reducer || reducer).bind(null, options);
 	options.keygen = (options.keygen || keygen).bind(null, options);
 
-	options.default = (options.default || {});
+	options.initialValue = (options.initialValue || {});
 
 	return options;
 }

--- a/test/require-glob.js
+++ b/test/require-glob.js
@@ -224,12 +224,12 @@ test('should use custom keygen', async (t) => {
 	t.deepEqual(deep, expected);
 });
 
-test('should use default value', async (t) => {
+test('should use initial value', async (t) => {
 	const result = await requireGlob([
 		'./fixtures/{deep,shallow}/**/*.js',
 		'!./**/a*',
 	], {
-		default: [],
+		initialValue: [],
 		reducer: (options, result, fileObject) => {
 			result.push(fileObject.exports);
 			return result;
@@ -241,8 +241,8 @@ test('should use default value', async (t) => {
 	t.deepEqual(result.sort(), expected.sort());
 });
 
-test('should return default value', async (t) => {
-	const result = await requireGlob([], { default: [] });
+test('should return initial value', async (t) => {
+	const result = await requireGlob([], { initialValue: [] });
 
 	const expected = [];
 

--- a/test/require-glob.js
+++ b/test/require-glob.js
@@ -223,3 +223,20 @@ test('should use custom keygen', async (t) => {
 
 	t.deepEqual(deep, expected);
 });
+
+test('should use default object', async (t) => {
+	const result = await requireGlob([
+		'./fixtures/{deep,shallow}/**/*.js',
+		'!./**/a*',
+	], {
+		default: [],
+		reducer: (options, result, fileObject) => {
+			result.push(fileObject.exports);
+			return result;
+		}
+	});
+
+	const expected = ['_b.b1','b.b2', 'b1', 'b2', 'b', 'c', { e: 'e' }];
+
+	t.deepEqual(result.sort(), expected.sort());
+});

--- a/test/require-glob.js
+++ b/test/require-glob.js
@@ -242,7 +242,7 @@ test('should use initial value', async (t) => {
 });
 
 test('should return initial value', async (t) => {
-	const result = await requireGlob([], { initialValue: [] });
+	const result = await requireGlob('./fixtures/bogu*.js', { initialValue: [] });
 
 	const expected = [];
 

--- a/test/require-glob.js
+++ b/test/require-glob.js
@@ -224,7 +224,7 @@ test('should use custom keygen', async (t) => {
 	t.deepEqual(deep, expected);
 });
 
-test('should use default object', async (t) => {
+test('should use default value', async (t) => {
 	const result = await requireGlob([
 		'./fixtures/{deep,shallow}/**/*.js',
 		'!./**/a*',
@@ -241,9 +241,9 @@ test('should use default object', async (t) => {
 	t.deepEqual(result.sort(), expected.sort());
 });
 
-test('should return default object', async (t) => {
+test('should return default value', async (t) => {
 	const result = await requireGlob([], { default: [] });
-	
+
 	const expected = [];
 
 	t.deepEqual(result, expected);

--- a/test/require-glob.js
+++ b/test/require-glob.js
@@ -240,3 +240,11 @@ test('should use default object', async (t) => {
 
 	t.deepEqual(result.sort(), expected.sort());
 });
+
+test('should return default object', async (t) => {
+	const result = await requireGlob([], { default: [] });
+	
+	const expected = [];
+
+	t.deepEqual(result, expected);
+});

--- a/test/require-glob.js
+++ b/test/require-glob.js
@@ -248,3 +248,23 @@ test('should return initial value', async (t) => {
 
 	t.deepEqual(result, expected);
 });
+
+test('should overwrite initial value', async (t) => {
+	const oneA = await requireGlob('./fixtures/rand*.js', {
+		initialValue: {
+			fixed: 'a',
+			random: 'b',
+		}
+	});
+	const oneB = requireGlob.sync('./fixtures/rand*.js', {
+		initialValue: {
+			fixed: 'a',
+			random: 'b',
+		}
+	});
+
+	t.equal(typeof oneA.fixed, 'string')
+	t.equal(typeof oneA.random, 'number');
+	t.equal(typeof oneB.fixed, 'string')
+	t.equal(typeof oneB.random, 'number');
+})


### PR DESCRIPTION
We have a use case for this library where it would reduce code complexity if we are allowed to set the initial value that is passed to the reducer. I added a simplified test to reflect the use case and made sure to remain backward compatible by passing an empty object by default, as expected by the default reducer.